### PR TITLE
Updating to work with v0.4.0+ Gaps

### DIFF
--- a/gaps-unraid.xml
+++ b/gaps-unraid.xml
@@ -40,8 +40,8 @@
   </Data>
   <Environment/>
   <Labels/>
-  <Config Name="UI" Target="8484" Default="" Mode="tcp" Description="Container Port: 8484" Type="Port" Display="always" Required="false" Mask="false">8484</Config>
-  <Config Name="SSL Boolean" Target="ENABLE_SSL" Default="" Mode="" Description="true/false to enable SSL" Type="Variable" Display="always" Required="false" Mask="false">false</Config>
-  <Config Name="Login Boolean" Target="ENABLE_LOGIN" Default="" Mode="" Description="true/false to enable login" Type="Variable" Display="always" Required="false" Mask="false">false</Config>
-  <Config Name="config" Target="/usr/data" Default="" Mode="rw" Description="File path for gaps config and data storage." Type="Path" Display="always" Required="false" Mask="false">/mnt/user/appdata/gaps/</Config>
+  <Config Name="UI" Target="8484" Default="" Mode="tcp" Description="Container Port: 8484" Type="Port" Display="always" Required="true" Mask="false">8484</Config>
+  <Config Name="SSL Boolean" Target="ENABLE_SSL" Default="" Mode="" Description="true/false to enable SSL" Type="Variable" Display="always" Required="true" Mask="false">false</Config>
+  <Config Name="Login Boolean" Target="ENABLE_LOGIN" Default="" Mode="" Description="true/false to enable login" Type="Variable" Display="always" Required="true" Mask="false">false</Config>
+  <Config Name="config" Target="/usr/data" Default="" Mode="rw" Description="File path for gaps config and data storage." Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/gaps/</Config>
 </Container>

--- a/gaps-unraid.xml
+++ b/gaps-unraid.xml
@@ -11,7 +11,7 @@
   <Project>https://github.com/JasonHHouse/Gaps/</Project>
   <Overview>Search your movies and find missing movies from MovieDB collections.</Overview>
   <Category>Tools: MediaApp:Other MediaServer:Other Status:Stable</Category>
-  <WebUI>https://[IP]:[PORT:8484]</WebUI>
+  <WebUI>http://[IP]:[PORT:8484]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/Knoxie/UnraidTemplates/master/gaps-unraid.xml</TemplateURL>
   <Icon>https://raw.githubusercontent.com/JasonHHouse/Gaps/master/images/gaps.png</Icon>
   <ExtraParams/>
@@ -41,5 +41,7 @@
   <Environment/>
   <Labels/>
   <Config Name="UI" Target="8484" Default="" Mode="tcp" Description="Container Port: 8484" Type="Port" Display="always" Required="false" Mask="false">8484</Config>
+  <Config Name="SSL Boolean" Target="ENABLE_SSL" Default="" Mode="" Description="true/false to enable SSL" Type="Variable" Display="always" Required="false" Mask="false">false</Config>
+  <Config Name="Login Boolean" Target="ENABLE_LOGIN" Default="" Mode="" Description="true/false to enable login" Type="Variable" Display="always" Required="false" Mask="false">false</Config>
   <Config Name="config" Target="/usr/data" Default="" Mode="rw" Description="File path for gaps config and data storage." Type="Path" Display="always" Required="false" Mask="false">/mnt/user/appdata/gaps/</Config>
 </Container>


### PR DESCRIPTION
Removing SSL from the URL by default. Adding two new config fields. SSL and Login enablers. Both defaulted to false.